### PR TITLE
fix: export this plugin's options interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,36 @@ const runtimePublicPath = '/@solid-refresh';
 const runtimeFilePath = require.resolve('solid-refresh/dist/solid-refresh.mjs');
 const runtimeCode = readFileSync(runtimeFilePath, 'utf-8');
 
+/** Configuration options for vite-plugin-solid. */
 export interface Options {
+  /**
+   * This will inject solid-js/dev in place of solid-js in dev mode. Has no 
+   * effect in prod. If set to `false`, it won't inject it in dev. This is  
+   * useful for extra logs and debugging.
+   *
+   * @default true
+   */
   dev: boolean;
+  /**
+   * This will force SSR code in the produced files. This is experiemental 
+   * and mostly not working yet.
+   *
+   * @default false
+   */
   ssr: boolean;
+  /**
+   * This will inject HMR runtime in dev mode. Has no effect in prod. If 
+   * set to `false`, it won't inject the runtime in dev.
+   *
+   * @default true
+   */
   hot: boolean;
+  /**
+   * Pass any additional babel transform options. They will be merged with 
+   * the transformations required by Solid.
+   *
+   * @default {}
+   */
   babel:
     | TransformOptions
     | ((source: string, id: string, ssr: boolean) => TransformOptions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const runtimePublicPath = '/@solid-refresh';
 const runtimeFilePath = require.resolve('solid-refresh/dist/solid-refresh.mjs');
 const runtimeCode = readFileSync(runtimeFilePath, 'utf-8');
 
-interface Options {
+export interface Options {
   dev: boolean;
   ssr: boolean;
   hot: boolean;


### PR DESCRIPTION
This PR exports the interface for this plugin's options and also adds jsdoc comments describing each option (I took the description for each option from this repo's README).