### PR TITLE
fix: ensure `solid-js` is included in pre-bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,29 +16,29 @@ const runtimeCode = readFileSync(runtimeFilePath, 'utf-8');
 /** Configuration options for vite-plugin-solid. */
 export interface Options {
   /**
-   * This will inject solid-js/dev in place of solid-js in dev mode. Has no 
-   * effect in prod. If set to `false`, it won't inject it in dev. This is  
+   * This will inject solid-js/dev in place of solid-js in dev mode. Has no
+   * effect in prod. If set to `false`, it won't inject it in dev. This is
    * useful for extra logs and debugging.
    *
    * @default true
    */
   dev: boolean;
   /**
-   * This will force SSR code in the produced files. This is experiemental 
+   * This will force SSR code in the produced files. This is experiemental
    * and mostly not working yet.
    *
    * @default false
    */
   ssr: boolean;
   /**
-   * This will inject HMR runtime in dev mode. Has no effect in prod. If 
+   * This will inject HMR runtime in dev mode. Has no effect in prod. If
    * set to `false`, it won't inject the runtime in dev.
    *
    * @default true
    */
   hot: boolean;
   /**
-   * Pass any additional babel transform options. They will be merged with 
+   * Pass any additional babel transform options. They will be merged with
    * the transformations required by Solid.
    *
    * @default {}
@@ -80,7 +80,7 @@ export default function solidPlugin(options: Partial<Options> = {}): Plugin {
           alias: [{ find: /^solid-refresh$/, replacement: runtimePublicPath }, ...alias],
         },
         optimizeDeps: {
-          include: ['solid-js/dev', 'solid-js/web'],
+          include: ['solid-js', 'solid-js/dev', 'solid-js/web'],
         },
       }) as UserConfig;
     },


### PR DESCRIPTION
_This PR is a necessary component of fixing solidui/solid-start#4._

In a standard, single project repo, running the vite dev server with this plugin (via `solid-start`) results in three dependencies being pre-bundled: `solid-js/web`, `solid-js`, and `solid-js/dev` even though this plugin only specifies `optimizeDeps.include: ['solid-js/dev', 'solid-js/web']`.

However, in a monorepo setup only two dependencies are pre-bundled: `solid-js/web` and `solid-js/dev`. This results in the following error during development (I never tested production) and the development build is never served

```
You appear to have multiple instances of Solid. This can lead to unexpected behavior.
computations created outside a `createRoot` or `render` will never be disposed
```

By adding `solid-js` to `optimizeDeps.include`, the `You appear to have multiple instances of Solid...` errors are eliminated and, in my testing, there appears to be no affect for single project repositories. I believe this PR is a necessary component of supporting monorepo development (the end user can also work around this issue by manually adding `optimizeDeps.include: ['solid-js']` to their local `vite.config.ts` file, but this bakes monorepo support into the plugin itself).